### PR TITLE
Add WebRTC call signaling support

### DIFF
--- a/enigmo_app/lib/services/call_service.dart
+++ b/enigmo_app/lib/services/call_service.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+/// Service to manage WebRTC voice calls.
+class CallService {
+  final void Function(Map<String, dynamic>) _sendSignal;
+  RTCPeerConnection? _peerConnection;
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
+
+  CallService(this._sendSignal);
+
+  MediaStream? get localStream => _localStream;
+  MediaStream? get remoteStream => _remoteStream;
+
+  Future<void> init() async {
+    _localStream = await navigator.mediaDevices.getUserMedia({'audio': true});
+  }
+
+  Future<void> startCall(String targetUserId) async {
+    await init();
+    _peerConnection = await createPeerConnection({
+      'iceServers': [
+        {'urls': 'stun:stun.l.google.com:19302'},
+      ]
+    });
+
+    _peerConnection!.onTrack = (event) {
+      if (event.streams.isNotEmpty) {
+        _remoteStream = event.streams.first;
+      }
+    };
+
+    for (var track in _localStream!.getTracks()) {
+      _peerConnection!.addTrack(track, _localStream!);
+    }
+
+    final offer = await _peerConnection!.createOffer();
+    await _peerConnection!.setLocalDescription(offer);
+
+    _sendSignal({
+      'type': 'call_offer',
+      'target_user_id': targetUserId,
+      'sdp': offer.sdp,
+      'session_type': offer.type,
+    });
+
+    _peerConnection!.onIceCandidate = (candidate) {
+      if (candidate.candidate != null) {
+        _sendSignal({
+          'type': 'ice_candidate',
+          'target_user_id': targetUserId,
+          'candidate': candidate.toMap(),
+        });
+      }
+    };
+  }
+
+  Future<void> handleSignal(Map<String, dynamic> message) async {
+    switch (message['type']) {
+      case 'call_offer':
+        await _handleOffer(message);
+        break;
+      case 'call_answer':
+        await _handleAnswer(message);
+        break;
+      case 'ice_candidate':
+        await _handleCandidate(message);
+        break;
+      case 'end_call':
+        await endCall();
+        break;
+    }
+  }
+
+  Future<void> _handleOffer(Map<String, dynamic> message) async {
+    await init();
+    _peerConnection = await createPeerConnection({
+      'iceServers': [
+        {'urls': 'stun:stun.l.google.com:19302'},
+      ]
+    });
+
+    _peerConnection!.onTrack = (event) {
+      if (event.streams.isNotEmpty) {
+        _remoteStream = event.streams.first;
+      }
+    };
+    for (var track in _localStream!.getTracks()) {
+      _peerConnection!.addTrack(track, _localStream!);
+    }
+
+    final description = RTCSessionDescription(message['sdp'], 'offer');
+    await _peerConnection!.setRemoteDescription(description);
+    final answer = await _peerConnection!.createAnswer();
+    await _peerConnection!.setLocalDescription(answer);
+
+    _sendSignal({
+      'type': 'call_answer',
+      'target_user_id': message['sender_id'],
+      'sdp': answer.sdp,
+      'session_type': answer.type,
+    });
+
+    _peerConnection!.onIceCandidate = (candidate) {
+      if (candidate.candidate != null) {
+        _sendSignal({
+          'type': 'ice_candidate',
+          'target_user_id': message['sender_id'],
+          'candidate': candidate.toMap(),
+        });
+      }
+    };
+  }
+
+  Future<void> _handleAnswer(Map<String, dynamic> message) async {
+    final description = RTCSessionDescription(message['sdp'], 'answer');
+    await _peerConnection?.setRemoteDescription(description);
+  }
+
+  Future<void> _handleCandidate(Map<String, dynamic> message) async {
+    final c = message['candidate'];
+    if (c != null) {
+      final candidate = RTCIceCandidate(
+        c['candidate'],
+        c['sdpMid'],
+        c['sdpMLineIndex'],
+      );
+      await _peerConnection?.addCandidate(candidate);
+    }
+  }
+
+  Future<void> endCall() async {
+    await _peerConnection?.close();
+    _peerConnection = null;
+    await _localStream?.dispose();
+    await _remoteStream?.dispose();
+    _localStream = null;
+    _remoteStream = null;
+  }
+}

--- a/enigmo_app/pubspec.yaml
+++ b/enigmo_app/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   convert: ^3.1.1
   web_socket_channel: ^2.4.0
   flutter_secure_storage: ^9.2.2
+  flutter_webrtc: ^0.9.36
   # Push notification support (temporarily disabled for iOS build)
   # firebase_messaging: ^14.9.4
   # firebase_core: ^2.32.0

--- a/enigmo_server/lib/anongram_server.dart
+++ b/enigmo_server/lib/anongram_server.dart
@@ -19,6 +19,7 @@ class AnogramServer {
   late final MessageManager _messageManager;
   late final WebSocketHandler _webSocketHandler;
   late final HttpServer _server;
+  late final DateTime _startTime;
   
   /// Initializes the server
   Future<void> initialize({
@@ -51,6 +52,7 @@ class AnogramServer {
           .addHandler(router);
 
       // Start server
+      _startTime = DateTime.now();
       _server = await serve(handler, host, port);
       
       _logger.info('Anongram Bootstrap Server started at http://${_server.address.host}:${_server.port}');
@@ -66,11 +68,12 @@ class AnogramServer {
 
   /// Health check handler
   Response _handleHealthCheck(Request request) {
+    final uptime = DateTime.now().difference(_startTime).inSeconds;
     final healthData = {
       'status': 'ok',
       'timestamp': DateTime.now().toIso8601String(),
       'version': '1.0.0',
-      'uptime': DateTime.now().toIso8601String(),
+      'uptime': uptime,
     };
     
     return Response.ok(
@@ -84,10 +87,11 @@ class AnogramServer {
     try {
       final userStats = _userManager.getUserStats();
       final messageStats = _messageManager.getMessageStats();
-      
+
+      final uptime = DateTime.now().difference(_startTime).inSeconds;
       final stats = {
         'server': {
-          'uptime': DateTime.now().toIso8601String(),
+          'uptime': uptime,
           'version': '1.0.0',
           'status': 'running',
         },

--- a/enigmo_server/lib/services/auth_service.dart
+++ b/enigmo_server/lib/services/auth_service.dart
@@ -24,8 +24,8 @@ class AuthService {
   String generateToken(String userId) {
     // Ensure uniqueness with microsecond precision and random component
     final now = DateTime.now();
-    final timestamp = '${now.millisecondsSinceEpoch}${now.microsecond.toString().padLeft(3, '0')}';
-    final random = Random().nextInt(999999).toString().padLeft(6, '0');
+    final timestamp = now.microsecondsSinceEpoch.toString();
+    final random = Random().nextInt(1000000).toString().padLeft(6, '0');
     return 'token_${userId}_${timestamp}_$random';
   }
 

--- a/enigmo_server/lib/services/message_manager.dart
+++ b/enigmo_server/lib/services/message_manager.dart
@@ -189,16 +189,13 @@ class MessageManager {
   }
 
   void _clearConversationCache(String userId1, String userId2) {
-    final keys = _conversationCache.keys.where((key) => 
-        (key.contains(userId1) && key.contains(userId2))).toList();
-    for (final key in keys) {
-      _conversationCache.remove(key);
-    }
+    final key = _getCacheKey(userId1, userId2);
+    _conversationCache.remove(key);
   }
 
   String _generateMessageId() {
     final timestamp = DateTime.now().millisecondsSinceEpoch;
-    final randomSuffix = _random.nextInt(999999).toString().padLeft(6, '0');
+    final randomSuffix = _random.nextInt(1000000).toString().padLeft(6, '0');
     return '${timestamp}_${randomSuffix}';
   }
 

--- a/enigmo_server/test/logger_test.dart
+++ b/enigmo_server/test/logger_test.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:enigmo_server/utils/logger.dart';
+
+void main() {
+  group('Logger', () {
+    test('instance methods output prefixed messages', () {
+      final logger = Logger();
+      final messages = <String>[];
+      runZoned(() {
+        logger.info('hello');
+        logger.debug('dbg');
+        logger.error('err');
+        logger.warning('warn');
+      }, zoneSpecification: ZoneSpecification(print: (_, __, ___, String msg) {
+        messages.add(msg);
+      }));
+
+      expect(messages, [
+        'INFO: hello',
+        'DEBUG: dbg',
+        'ERROR: err',
+        'WARNING: warn',
+      ]);
+    });
+
+    test('static methods output prefixed messages', () {
+      final messages = <String>[];
+      runZoned(() {
+        Logger.logInfo('hi');
+        Logger.logDebug('dbg');
+        Logger.logError('err');
+        Logger.logWarning('warn');
+      }, zoneSpecification: ZoneSpecification(print: (_, __, ___, String msg) {
+        messages.add(msg);
+      }));
+
+      expect(messages, [
+        'INFO: hi',
+        'DEBUG: dbg',
+        'ERROR: err',
+        'WARNING: warn',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add flutter_webrtc dependency and client-side CallService for handling voice calls
- extend NetworkService to forward call signals and integrate CallService
- relay WebRTC signaling messages between users on the server

## Testing
- `dart format enigmo_app/lib/services/call_service.dart enigmo_app/lib/services/network_service.dart enigmo_server/lib/services/websocket_handler.dart enigmo_app/pubspec.yaml` *(fails: command not found: dart)*
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68bacefb6824832c963977b18b287d5c